### PR TITLE
Removed redundant all parameter constructor annotation in RedisCacheService.

### DIFF
--- a/src/main/java/com/uci/utils/cache/service/RedisCacheService.java
+++ b/src/main/java/com/uci/utils/cache/service/RedisCacheService.java
@@ -23,7 +23,6 @@ import java.util.concurrent.TimeUnit;
 @Service
 @Getter
 @Setter
-@AllArgsConstructor
 @Slf4j
 public class RedisCacheService {
 	private RedisTemplate<String, Object> redisTemplate;

--- a/src/test/java/com/uci/utils/cache/service/RedisCacheServiceTest.java
+++ b/src/test/java/com/uci/utils/cache/service/RedisCacheServiceTest.java
@@ -24,7 +24,7 @@ class RedisCacheServiceTest {
     @BeforeEach
     void init(){
         RedisTemplate<String, Object> obj = new RedisTemplate<>();
-        redisCacheService = Mockito.spy(new RedisCacheService(obj));
+        redisCacheService = Mockito.spy(new RedisCacheService());
         Mockito.doReturn(obj).when(redisCacheService).getCache(anyString());
         Mockito.doNothing().when(redisCacheService).setCache(anyString(), Mockito.any());
         Mockito.doNothing().when(redisCacheService).deleteCache(anyString());


### PR DESCRIPTION
This annotation is unnecessary since the only parameter is a RestTemplate object and should not be passed directly and be automatically injected. Keeping this tag hinders testing as it requires manually passing a RestTemplate object.